### PR TITLE
Fix typographical error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ When you have the project built, you can run it by invoking the binary:
      completion  Generate the autocompletion script for the specified shell
      help        Help about any command
      query       Query if the number is fizz/buzz or fizzbuzz
-     serve       Run an http server to anser fizzbuzz queries
+     serve       Run an http server to answer fizzbuzz queries
 
    Flags:
      -h, --help   help for fizzbuzz

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -16,7 +16,7 @@ import (
 // serveCmd represents the serve command
 var serveCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "Run an http server to anser fizzbuzz queries",
+	Short: "Run an http server to answer fizzbuzz queries",
 	Run: func(cmd *cobra.Command, args []string) {
 		tmpl := template.Must(template.ParseFiles("templates/index.html"))
 		type QueryContext struct {


### PR DESCRIPTION
`anser` to `answer`

![gif](https://y.yarn.co/376675a3-6595-4d5a-8e7f-300f0c6eb945_text.gif)